### PR TITLE
add meta for mobile and tablet devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 	<title>Page Title</title>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
 	<script src="jquery.mobilemenu.js"></script>
 	<script>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
 	<meta charset="utf-8">
 	<title>Page Title</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
 	<script src="jquery.mobilemenu.js"></script>
 	<script>


### PR DESCRIPTION
Your demo allows for testing on desktop, but doesn't allow for testing on mobile and tablet. 

The `<meta name="viewport" content="width=device-width, initial-scale=1">` tag solves this. I've tested on Chrome for mobile and Maxthon - everything working smoothly.

[demo](http://larrybotha.github.com/Responsive-Menu/)
